### PR TITLE
Fix typo in middleware.rb

### DIFF
--- a/lib/dynoscale_ruby/middleware.rb
+++ b/lib/dynoscale_ruby/middleware.rb
@@ -26,7 +26,7 @@ module DynoscaleRuby
         puts "Missing DYNOSCALE_URL environment variable"
         return @app.call(env)
       end 
-      return @app.call(env) if ENV['SKIP_DYNASCALE_AGENT']
+      return @app.call(env) if ENV['SKIP_DYNOSCALE_AGENT']
       return @app.call(env) unless is_dev || ENV['DYNO']&.split(".")&.last == "1"
 
       request_calculator = RequestCalculator.new(env)


### PR DESCRIPTION
## What
Fixes a typo in the middleware.rb

`SKIP_DYNASCALE_AGENT` -> `SKIP_DYNOSCALE_AGENT`