### PR TITLE
Skip Dynoscale Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ Some blog posts about why Dynoscale is a helpful tool.
 * [How to setup heroku autoscaling in under 15 minutes?](https://dynoscale.net/blog/how-to-setup-heroku-autoscaling-in-under-15-minutes)
 * [Level up your Heroku autoscaling in 15 minutes](http://localhost:5008/blog/level-up-your-heroku-autoscaling-in-15-minutes)
 
+## Skip Dynoscale Agent
+
+In review apps, staging or development environments, set the `SKIP_DYNOSCALE_AGENT` environment variable to disable the scaling agent on all web and worker processes.
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/Mjolnir-Software/dynoscale_ruby.

--- a/lib/dynoscale_ruby/middleware.rb
+++ b/lib/dynoscale_ruby/middleware.rb
@@ -19,14 +19,15 @@ module DynoscaleRuby
     end
 
     def call(env)
+      return @app.call(env) if ENV['SKIP_DYNOSCALE_AGENT']
+
       is_dev = ENV['DYNOSCALE_DEV'] == 'true'
       dyno = is_dev ? "dev.1" : ENV['DYNO']
 
       unless ENV['DYNOSCALE_URL']
         puts "Missing DYNOSCALE_URL environment variable"
         return @app.call(env)
-      end 
-      return @app.call(env) if ENV['SKIP_DYNASCALE_AGENT']
+      end
       return @app.call(env) unless is_dev || ENV['DYNO']&.split(".")&.last == "1"
 
       request_calculator = RequestCalculator.new(env)

--- a/lib/dynoscale_ruby/worker/resque.rb
+++ b/lib/dynoscale_ruby/worker/resque.rb
@@ -6,6 +6,8 @@ module DynoscaleRuby
       include Singleton
 
       def self.enabled?
+        return false if ENV['SKIP_DYNOSCALE_AGENT']
+
         require 'resque'
         require 'resque_latency'
         true
@@ -29,4 +31,3 @@ module DynoscaleRuby
     end
   end
 end
-

--- a/lib/dynoscale_ruby/worker/sidekiq.rb
+++ b/lib/dynoscale_ruby/worker/sidekiq.rb
@@ -6,6 +6,8 @@ module DynoscaleRuby
       include Singleton
 
       def self.enabled?
+        return false if ENV['SKIP_DYNOSCALE_AGENT']
+
         require 'sidekiq/api'
         true
       rescue LoadError


### PR DESCRIPTION
In review apps, staging or development environments the agent may not need to send reports to the Dynoscale server.

Moved the skip check from the middleware to the top to avoid receiving the "Missing DYNOSCALE_URL environment variable" message when the agent is disabled.

Updated worker adapters to check if the agent was skipped.